### PR TITLE
Feature to create ILB sets

### DIFF
--- a/src/imagelightbox.js
+++ b/src/imagelightbox.js
@@ -27,6 +27,9 @@
         $navObject = $('<div/>', {
             id: 'imagelightbox-nav'
         }),
+        $navItem = $('<a/>', {
+            href:'#',class:"imagelightbox-navitem"
+        }),
         //
         $wrapper = $('<div/>', {
             id: 'imagelightbox-wrapper'
@@ -119,6 +122,7 @@
                     }
                 },
                 onEnd: function () {
+                    targets = $([]);
                     $wrapper.remove().find("*").remove();
                     if (options.lockBody) {
                         lockBody(false);
@@ -211,10 +215,10 @@
                 $captionObject.remove();
             },
             navigationOn = function (instance, selector) {
-                var images = $(selector);
+                var images = targets;
                 if (images.length) {
                     for (var i = 0; i < images.length; i++) {
-                        $navObject.append($('<a/>',{href:'#'}));
+                        $navObject.append($navItem.clone());
                     }
                     $wrapper.append($navObject);
                     $navObject.on('click touchend', function () {
@@ -242,7 +246,7 @@
             navigationUpdate = function (selector) {
                 var items = $navObject.find('a');
                 items.removeClass('active');
-                items.eq($(selector).filter('[href="' + $('#imagelightbox').attr('src') + '"]').index(selector)).addClass('active');
+                items.eq(targets.index(target)).addClass('active');
             },
             navigationOff = function () {
                 $('#imagelightbox-nav').remove();
@@ -262,7 +266,7 @@
             arrowsOff = function () {
                 $('.imagelightbox-arrow').remove();
             },
-
+            targetSet = "",
             targets = $([]),
             target = $(),
             image = $(),
@@ -489,14 +493,21 @@
             },
 
             _addTargets = function( newTargets ) {
-                newTargets.each(function () {
-                    targets = targets.add($(this));
-                });
-
-                newTargets.on('click', function (e) {
+                newTargets.on('click.imagelightbox', {set: targetSet}, function (e) {
                     e.preventDefault();
+                    targetSet = $(e.currentTarget).data("imagelightbox");
+                    filterTargets();
                     _openImageLightbox($(this));
                 });
+                function filterTargets () {
+                    newTargets
+                        .filter(function () {
+                            return $(this).data("imagelightbox") === targetSet;
+                        })
+                        .each(function () {
+                            targets = targets.add($(this));
+                        });
+                }
             };
 
         this.startImageLightbox = function () {


### PR DESCRIPTION
This PR adjusts event listeners and targeting such that an Image Lightbox set is created based on the value of the data-imagelightbox attribute.

You still do as usual to call...
````js
$("a[data-imagelightbox]").imageLightbox({...});
````

The difference in usage (more like a different way of thinking about ILB):
````HTML
<a href="/img1.png" data-imagelightbox="a"></a>
<a href="/img2.png" data-imagelightbox="a"></a>

<a href="/img3.png" data-imagelightbox="b"></a>
````
When the user clicks link to image "img1.png", a set is created for each data-imagelightbox equal to, here, "a"; it will include "img1.png" and "img2.png".

Clicking the link to "img3.png" will create a separate ILB set.

In summary, the user can now have multiple galleries with their own ILB instance all on one webpage.

EDIT: grammar