### PR TITLE
towards a mimetype checker

### DIFF
--- a/src/imagelightbox.js
+++ b/src/imagelightbox.js
@@ -88,7 +88,7 @@
         var options = $.extend({
                 selector:       'a[data-imagelightbox]',
                 id:             'imagelightbox',
-                allowedTypes:   'png|jpg|jpeg||gif', // TODO make it work again
+                allowedTypes:   'png|jpg|jpeg|gif', // TODO make it work again
                 animationSpeed: 250,
                 activity:       false,
                 arrows:         false,
@@ -276,8 +276,46 @@
             inProgress = false,
 
             isTargetValid = function (validImage) {
-                console.log(validImage);
-                //return options.allowedTypes.test();
+                var allowedTypes = options.allowedTypes;
+
+                //test that RegExp is restricted to disjunction format
+                var isGoodRE = /^(?!\|)[\w\|]+(?!\|)$/.test(allowedTypes);
+                //
+                if (!isGoodRE) {
+                    //allowedTypes = 'png|jpg|jpeg|gif';
+                    return false;
+                }
+                //
+                var URL = validImage.attr("href");
+                var ext = parseURL(URL).pathname;
+                var re = new RegExp(allowedTypes,"i");
+                //
+                var isAllowed = re.test(ext);
+                // function by Cory LaViska
+                function parseURL(url) {
+                    var parser = document.createElement('a'),
+                        searchObject = {},
+                        queries, split, i;
+                    // Let the browser do the work
+                    parser.href = url;
+                    // Convert query string to object
+                    queries = parser.search.replace(/^\?/, '').split('&');
+                    for( i = 0; i < queries.length; i++ ) {
+                        split = queries[i].split('=');
+                        searchObject[split[0]] = split[1];
+                    }
+                    return {
+                        protocol: parser.protocol,
+                        host: parser.host,
+                        hostname: parser.hostname,
+                        port: parser.port,
+                        pathname: parser.pathname,
+                        search: parser.search,
+                        searchObject: searchObject,
+                        hash: parser.hash
+                    };
+                }
+                return isAllowed;
             },
             // TODO make it work again
             // isTargetValid = function (element) {
@@ -511,7 +549,7 @@
                             return $(this).data("imagelightbox") === targetSet;
                         })
                         .filter(function () {
-                           // isTargetValid($(this));
+                           return isTargetValid($(this));
                         })
                         .each(function () {
                             targets = targets.add($(this));

--- a/src/imagelightbox.js
+++ b/src/imagelightbox.js
@@ -275,6 +275,10 @@
             swipeDiff = 0,
             inProgress = false,
 
+            isTargetValid = function (validImage) {
+                console.log(validImage);
+                //return options.allowedTypes.test();
+            },
             // TODO make it work again
             // isTargetValid = function (element) {
             //   var classic = $(element).prop('tagName').toLowerCase() === 'a' && ( new RegExp('.(' + options.allowedTypes + ')$', 'i') ).test($(element).attr('href'));
@@ -505,6 +509,9 @@
                     newTargets
                         .filter(function () {
                             return $(this).data("imagelightbox") === targetSet;
+                        })
+                        .filter(function () {
+                           // isTargetValid($(this));
                         })
                         .each(function () {
                             targets = targets.add($(this));


### PR DESCRIPTION
Hey @rejas 

I started working on that leftover problem regarding the validity of targets (effectively another target filter). Contrary to branch name, this code does not check mimetype, just extension.

What are the use cases?
• If user is creating ILB links programmatically on the client side, ILB can ensure only certain images types are used for a given gallery.

I cannot think of another use case. You? Also, what is "classic versus html5" supposed to convey?
