### PR TITLE
fixed demo of dyno add

### DIFF
--- a/docs/javascripts/main.js
+++ b/docs/javascripts/main.js
@@ -50,14 +50,14 @@ $(document).ready(function() {
         var adding_ul = $("#dynamically_adding");
         var li = $('<li></li>').appendTo( adding_ul );
         var a = $("<a></a>")
-            .attr('data-imagelightbox',"add")
+            .attr('data-imagelightbox',"i")
             .attr('href', "images/demo4.jpg")
             .appendTo( li );
         $("<img />")
             .attr("src", "images/thumb4.jpg")
             .appendTo( a );
         // dynamically adding
-        instanceI.addToImageLightbox( $("a[data-imagelightbox='add']") );
+        instanceI.addToImageLightbox( $("a[data-imagelightbox='i']") );
     });
 
     $('a[data-imagelightbox="j"]').imageLightbox({


### PR DESCRIPTION
So, the problem here is the "user" code; that is, the code in "main.js". Rather than associating the dynamically added images with an "established" ILB set, you are creating a new one with the `data-imagelightbox` value of `add` as opposed to `i`, which is the set I think you wanted to associate the dynamically added images with.

It's working now, but, if you don't mind, don't merge just yet. I think the example code for dynamically adding can be streamlined.

EDIT:
>  I think the example code for dynamically adding can be streamlined.

Oh, disregard that nonsense